### PR TITLE
improve error handling for matching annotations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,11 @@ RUN make test all
 FROM alpine:latest
 ENV TLS_PORT=9443 \
     LIFECYCLE_PORT=9000 \
-    CONFIG=./conf/sidecars.yaml \
     TLS_CERT_FILE=/var/lib/secrets/cert.crt \
     TLS_KEY_FILE=/var/lib/secrets/cert.key
 RUN apk --no-cache add ca-certificates bash
 COPY --from=0 /src/bin/k8s-sidecar-injector /bin/k8s-sidecar-injector
-COPY ./conf ./conf
+COPY ./conf /conf
 COPY ./entrypoint.sh /bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
 EXPOSE $TLS_PORT $LIFECYCLE_PORT

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -129,7 +129,7 @@ func main() {
 				}
 				glog.V(1).Infof("got %d updated InjectionConfigs from reconciliation", len(updatedInjectionConfigs))
 
-				newInjectionConfigs := make([]config.InjectionConfig, len(updatedInjectionConfigs)+len(cfg.Injections))
+				newInjectionConfigs := make([]*config.InjectionConfig, len(updatedInjectionConfigs)+len(cfg.Injections))
 				{
 					i := 0
 					for k := range cfg.Injections {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 LIFECYCLE_PORT="${LIFECYCLE_PORT:-9000}"
 TLS_PORT="${TLS_PORT:-9443}"
-CONFIG_DIR="${CONFIG_DIR:-conf/}"
+CONFIG_DIR="${CONFIG_DIR:-/conf}"
 TLS_CERT_FILE="${TLS_CERT_FILE:-/var/lib/secrets/cert.crt}"
 TLS_KEY_FILE="${TLS_KEY_FILE:-/var/lib/secrets/cert.key}"
 CONFIGMAP_LABELS="${CONFIGMAP_LABELS:-app=k8s-sidecar-injector}"

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/ghodss/yaml"
@@ -64,7 +65,7 @@ func (c *Config) ReplaceInjectionConfigs(replacementConfigs []InjectionConfig) {
 func (c *Config) HasInjectionConfig(key string) bool {
 	c.RLock()
 	defer c.RUnlock()
-	_, ok := c.Injections[key]
+	_, ok := c.Injections[strings.ToLower(key)]
 	return ok
 }
 
@@ -72,7 +73,8 @@ func (c *Config) HasInjectionConfig(key string) bool {
 func (c *Config) GetInjectionConfig(key string) (*InjectionConfig, error) {
 	c.RLock()
 	defer c.RUnlock()
-	i, ok := c.Injections[key]
+	k := strings.ToLower(key)
+	i, ok := c.Injections[k]
 	if !ok {
 		return nil, fmt.Errorf("no injection config found for annotation %s", key)
 	}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -40,8 +40,8 @@ type InjectionConfig struct {
 // Config is a struct indicating how a given injection should be configured
 type Config struct {
 	sync.RWMutex
-	AnnotationNamespace string                     `yaml:"annotationnamespace"`
-	Injections          map[string]InjectionConfig `yaml:"injections"`
+	AnnotationNamespace string                      `yaml:"annotationnamespace"`
+	Injections          map[string]*InjectionConfig `yaml:"injections"`
 }
 
 // String returns a string representation of the config
@@ -51,10 +51,10 @@ func (c *InjectionConfig) String() string {
 
 // ReplaceInjectionConfigs will take a list of new InjectionConfigs, and replace the current configuration with them.
 // this blocks waiting on being able to update the configs in place.
-func (c *Config) ReplaceInjectionConfigs(replacementConfigs []InjectionConfig) {
+func (c *Config) ReplaceInjectionConfigs(replacementConfigs []*InjectionConfig) {
 	c.Lock()
 	defer c.Unlock()
-	c.Injections = map[string]InjectionConfig{}
+	c.Injections = map[string]*InjectionConfig{}
 	for _, r := range replacementConfigs {
 		c.Injections[r.Name] = r
 	}
@@ -78,13 +78,13 @@ func (c *Config) GetInjectionConfig(key string) (*InjectionConfig, error) {
 	if !ok {
 		return nil, fmt.Errorf("no injection config found for annotation %s", key)
 	}
-	return &i, nil
+	return i, nil
 }
 
 // LoadConfigDirectory loads all configs in a directory and returns the Config
 func LoadConfigDirectory(path string) (*Config, error) {
 	cfg := Config{
-		Injections: map[string]InjectionConfig{},
+		Injections: map[string]*InjectionConfig{},
 	}
 	glob := filepath.Join(path, "*.yaml")
 	matches, err := filepath.Glob(glob)
@@ -97,7 +97,7 @@ func LoadConfigDirectory(path string) (*Config, error) {
 			glog.Errorf("Error reading injection config from %s: %v", p, err)
 			return nil, err
 		}
-		cfg.Injections[c.Name] = *c
+		cfg.Injections[c.Name] = c
 	}
 
 	if len(cfg.Injections) == 0 {

--- a/internal/pkg/config/watcher/watcher.go
+++ b/internal/pkg/config/watcher/watcher.go
@@ -135,7 +135,7 @@ func mapStringStringToLabelSelector(m map[string]string) string {
 }
 
 // Get fetches all matching ConfigMaps
-func (c *K8sConfigMapWatcher) Get() (cfgs []config.InjectionConfig, err error) {
+func (c *K8sConfigMapWatcher) Get() (cfgs []*config.InjectionConfig, err error) {
 	glog.V(1).Infof("Fetching ConfigMaps...")
 	clist, err := c.client.ConfigMaps(c.Namespace).List(metav1.ListOptions{
 		LabelSelector: mapStringStringToLabelSelector(c.ConfigMapLabels),
@@ -156,8 +156,8 @@ func (c *K8sConfigMapWatcher) Get() (cfgs []config.InjectionConfig, err error) {
 }
 
 // InjectionConfigsFromConfigMap parse items in a configmap into a list of InjectionConfigs
-func InjectionConfigsFromConfigMap(cm v1.ConfigMap) ([]config.InjectionConfig, error) {
-	ics := []config.InjectionConfig{}
+func InjectionConfigsFromConfigMap(cm v1.ConfigMap) ([]*config.InjectionConfig, error) {
+	ics := []*config.InjectionConfig{}
 	for name, payload := range cm.Data {
 		glog.V(3).Infof("Parsing %s/%s:%s into InjectionConfig", cm.ObjectMeta.Namespace, cm.ObjectMeta.Name, name)
 		ic, err := config.LoadInjectionConfig(strings.NewReader(payload))
@@ -165,7 +165,7 @@ func InjectionConfigsFromConfigMap(cm v1.ConfigMap) ([]config.InjectionConfig, e
 			return nil, fmt.Errorf("error parsing ConfigMap %s item %s into injection config: %s", cm.ObjectMeta.Name, name, err.Error())
 		}
 		glog.V(2).Infof("Loaded InjectionConfig %s from ConfigMap %s:%s", ic.Name, cm.ObjectMeta.Name, name)
-		ics = append(ics, *ic)
+		ics = append(ics, ic)
 	}
 	return ics, nil
 }

--- a/pkg/server/errors.go
+++ b/pkg/server/errors.go
@@ -1,0 +1,16 @@
+package server
+
+import (
+	"fmt"
+)
+
+var (
+	// ErrSkipIgnoredNamespace ...
+	ErrSkipIgnoredNamespace = fmt.Errorf("Skipping pod in ignored namespace")
+	// ErrSkipAlreadyInjected ...
+	ErrSkipAlreadyInjected = fmt.Errorf("Skipping pod that has already been injected")
+	// ErrMissingRequestAnnotation ...
+	ErrMissingRequestAnnotation = fmt.Errorf("Missing injection request annotation")
+	// ErrRequestedSidecarNotFound ...
+	ErrRequestedSidecarNotFound = fmt.Errorf("Requested sidecar not found in configuration")
+)

--- a/pkg/server/errors.go
+++ b/pkg/server/errors.go
@@ -14,3 +14,24 @@ var (
 	// ErrRequestedSidecarNotFound ...
 	ErrRequestedSidecarNotFound = fmt.Errorf("Requested sidecar not found in configuration")
 )
+
+// GetErrorReason returns a string description for a given error, for use
+// when reporting "reason" in metrics
+func GetErrorReason(err error) string {
+	var reason string
+	switch err {
+	case ErrSkipIgnoredNamespace:
+		reason = "ignored_namespace"
+	case ErrSkipAlreadyInjected:
+		reason = "already_injected"
+	case ErrMissingRequestAnnotation:
+		reason = "no_annotation"
+	case ErrRequestedSidecarNotFound:
+		reason = "missing_config"
+	case nil:
+		reason = ""
+	default:
+		reason = "unknown_error"
+	}
+	return reason
+}

--- a/test/fixtures/k8s/bad-sidecar.yaml
+++ b/test/fixtures/k8s/bad-sidecar.yaml
@@ -1,0 +1,4 @@
+name: bad-sidecar
+namespace: "test-namespace"
+annotations:
+  "injector.unittest.com/request": "this-doesnt-exist"

--- a/test/fixtures/k8s/ignored-namespace-pod.yaml
+++ b/test/fixtures/k8s/ignored-namespace-pod.yaml
@@ -1,0 +1,4 @@
+name: ignored-namespace
+namespace: "ignore-me"
+annotations:
+  "injector.unittest.com/request": "volume-mounts"


### PR DESCRIPTION
# What and why?

This PR improves flow of matching requested sidecar configurations in the mutation handler. A bit of refactoring was necessary to make error conditions more clear, and map those failures to clear reasons in exposed metrics. I have also beefed up tests some to cover all the error cases the mutation route can get into.

# Testing Steps

`make test all`

# Reviewers

Required reviewers: @defect @alex-laties @komapa @roymarantz @gtorre 
Request reviews from other people you want to review this PR in the "Reviewers" section on the right.

> :warning: this PR must have at least 2 thumbs from the [MAINTAINERS.md](/MAINTAINERS.md) of the project before merging!
