### PR TITLE
Feature/inject host aliases

### DIFF
--- a/docs/sidecar-configuration-format.md
+++ b/docs/sidecar-configuration-format.md
@@ -52,6 +52,10 @@ env:
 - name: DATACENTER
   value: "dc01"
 
+# all volumeMounts defined here will be added to containers, if the .name attribute
+# does not already exist in the list of volumeMounts, i.e. no replacement will be done.
+# They will be added to each container, including the ones added via injection.
+# This behaviour is the same for environment variables.
 volumeMounts:
   - name: some-config
     mountPath: /etc/some-config

--- a/docs/sidecar-configuration-format.md
+++ b/docs/sidecar-configuration-format.md
@@ -31,14 +31,30 @@ volumes:
 - name: nginx-conf
   configMap:
     name: nginx-configmap
+- name: some-config
+  configMap:
+    name: some-configmap
+
+# hostAliases are not being merged, only added, as they only add entries to /etc/hosts in the containers.
+# Duplicate entries won't throw an error.
+# hostAliases are used for the whole pod.
+hostAliases:
+  - ip: 1.2.3.4
+    hostnames:
+      - somehost.example.com
+      - anotherhost.example.com
 
 # all environment variables defined here will be added to containers _only_ if the .Name
 # is not already present (we will not replace an env var, only add them)
 # These will be inserted into each container in the pod, including any containers added via
-# injection.
+# injection. The same applies to volumeMounts.
 env:
 - name: DATACENTER
   value: "dc01"
+
+volumeMounts:
+  - name: some-config
+    mountPath: /etc/some-config
 ```
 
 ## Configuring new sidecars
@@ -47,8 +63,6 @@ In order for the injector to know about a sidecar configuration, you need to eit
 
 1. Create a new InjectionConfiguration `yaml`
   1. Specify your `name:`. This is what you will request with `injector.tumblr.com/request=$name`
-  2. Fill in the `containers`, `volumes`, and `env` fields with your configuration you want injected
+  2. Fill in the `containers`, `volumes`, `volumeMounts`, `hostAliases` and `env` fields with your configuration you want injected
 2. Either bake your yaml into your Docker image you run (in `--config-directory=conf/`), or configure it as a ConfigMap in your k8s cluster. See [/docs/configmaps.md](/docs/configmaps.md) for information on how to configure a ConfigMap.
 3. Deploy a pod with annotation `injector.tumblr.com/request=$name`!
-
-

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -35,6 +35,7 @@ type InjectionConfig struct {
 	Volumes      []corev1.Volume      `json:"volumes"`
 	Environment  []corev1.EnvVar      `json:"env"`
 	VolumeMounts []corev1.VolumeMount `json:"volumeMounts"`
+	HostAliases  []corev1.HostAlias   `json:"hostAliases"`
 }
 
 // Config is a struct indicating how a given injection should be configured
@@ -46,7 +47,7 @@ type Config struct {
 
 // String returns a string representation of the config
 func (c *InjectionConfig) String() string {
-	return fmt.Sprintf("%s: %d containers, %d volumes, %d environment vars, %d volume mounts", c.Name, len(c.Containers), len(c.Volumes), len(c.Environment), len(c.VolumeMounts))
+	return fmt.Sprintf("%s: %d containers, %d volumes, %d environment vars, %d volume mounts, %d host aliases", c.Name, len(c.Containers), len(c.Volumes), len(c.Environment), len(c.VolumeMounts), len(c.HostAliases))
 }
 
 // ReplaceInjectionConfigs will take a list of new InjectionConfigs, and replace the current configuration with them.

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -172,7 +172,7 @@ func TestLoadHostAliasesConfig(t *testing.T) {
 	nExpectedVolumes := 0
 	nExpectedEnvironmentVars := 2
 	nExpectedVolumeMounts := 0
-	nExpectedHostAliases := 2
+	nExpectedHostAliases := 6
 
 	if c.Name != expectedName {
 		t.Fatalf("expected %s Name loaded from %s but got %s", expectedName, cfg, c.Name)

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -12,11 +12,11 @@ var (
 	complicatedConfig = sidecars + "/complex-sidecar.yaml"
 	env1              = sidecars + "/env1.yaml"
 	volumeMounts      = sidecars + "/volume-mounts.yaml"
-	hostAliases       = sidecars + "host-aliases.yaml"
+	hostAliases       = sidecars + "/host-aliases.yaml"
 )
 
 func TestLoadConfig(t *testing.T) {
-	expectedNumInjectionsConfig := 4
+	expectedNumInjectionsConfig := 5
 	c, err := LoadConfigDirectory(sidecars)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -12,6 +12,7 @@ var (
 	complicatedConfig = sidecars + "/complex-sidecar.yaml"
 	env1              = sidecars + "/env1.yaml"
 	volumeMounts      = sidecars + "/volume-mounts.yaml"
+	hostAliases       = sidecars + "host-aliases.yaml"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -41,6 +42,7 @@ func TestLoadEnvironmentInjectionConfig(t *testing.T) {
 	expectedContainerCount := 0
 	expectedVolumeCount := 0
 	nExpectedVolumeMounts := 0
+	nExpectedHostAliases := 0
 	if c.Name != expectedName {
 		t.Errorf("expected %s Name loaded from %s but got %s", expectedName, cfg, c.Name)
 		t.Fail()
@@ -59,6 +61,9 @@ func TestLoadEnvironmentInjectionConfig(t *testing.T) {
 	}
 	if len(c.VolumeMounts) != nExpectedVolumeMounts {
 		t.Fatalf("expected %d VolumeMounts loaded from %s but got %d", nExpectedVolumeMounts, cfg, len(c.VolumeMounts))
+	}
+	if len(c.HostAliases) != nExpectedHostAliases {
+		t.Fatalf("expected %d HostAliases loaded from %s but got %d", nExpectedHostAliases, cfg, len(c.HostAliases))
 	}
 }
 
@@ -84,6 +89,9 @@ func TestLoadInjectionConfig1(t *testing.T) {
 	if len(c.VolumeMounts) != 0 {
 		t.Fatalf("expected %d VolumeMounts loaded from %s but got %d", 0, cfg, len(c.VolumeMounts))
 	}
+	if len(c.HostAliases) != 0 {
+		t.Fatalf("expected %d HostAliases loaded from %s but got %d", 0, cfg, len(c.HostAliases))
+	}
 }
 
 // load a more complicated test config with LOTS of configuration
@@ -98,6 +106,8 @@ func TestLoadComplexConfig(t *testing.T) {
 	nExpectedVolumes := 1
 	nExpectedEnvironmentVars := 0
 	nExpectedVolumeMounts := 0
+	nExpectedHostAliases := 0
+
 	if c.Name != expectedName {
 		t.Fatalf("expected %s Name loaded from %s but got %s", expectedName, cfg, c.Name)
 	}
@@ -112,6 +122,9 @@ func TestLoadComplexConfig(t *testing.T) {
 	}
 	if len(c.VolumeMounts) != nExpectedVolumeMounts {
 		t.Fatalf("expected %d VolumeMounts loaded from %s but got %d", nExpectedVolumeMounts, cfg, len(c.VolumeMounts))
+	}
+	if len(c.HostAliases) != nExpectedHostAliases {
+		t.Fatalf("expected %d HostAliases loaded from %s but got %d", nExpectedHostAliases, cfg, len(c.HostAliases))
 	}
 }
 
@@ -126,6 +139,7 @@ func TestLoadVolumeMountsConfig(t *testing.T) {
 	nExpectedVolumes := 2
 	nExpectedEnvironmentVars := 2
 	nExpectedVolumeMounts := 1
+	nExpectedHostAliases := 0
 
 	if c.Name != expectedName {
 		t.Fatalf("expected %s Name loaded from %s but got %s", expectedName, cfg, c.Name)
@@ -141,6 +155,42 @@ func TestLoadVolumeMountsConfig(t *testing.T) {
 	}
 	if len(c.VolumeMounts) != nExpectedVolumeMounts {
 		t.Fatalf("expected %d VolumeMounts loaded from %s but got %d", nExpectedVolumeMounts, cfg, len(c.VolumeMounts))
+	}
+	if len(c.HostAliases) != nExpectedHostAliases {
+		t.Fatalf("expected %d HostAliases loaded from %s but got %d", nExpectedHostAliases, cfg, len(c.HostAliases))
+	}
+}
+
+func TestLoadHostAliasesConfig(t *testing.T) {
+	cfg := hostAliases
+	c, err := LoadInjectionConfigFromFilePath(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedName := "host-aliases"
+	nExpectedContainers := 2
+	nExpectedVolumes := 0
+	nExpectedEnvironmentVars := 2
+	nExpectedVolumeMounts := 0
+	nExpectedHostAliases := 2
+
+	if c.Name != expectedName {
+		t.Fatalf("expected %s Name loaded from %s but got %s", expectedName, cfg, c.Name)
+	}
+	if len(c.Environment) != nExpectedEnvironmentVars {
+		t.Fatalf("expected %d EnvVars loaded from %s but got %d", nExpectedEnvironmentVars, cfg, len(c.Environment))
+	}
+	if len(c.Containers) != nExpectedContainers {
+		t.Fatalf("expected %d Containers loaded from %s but got %d", nExpectedContainers, cfg, len(c.Containers))
+	}
+	if len(c.Volumes) != nExpectedVolumes {
+		t.Fatalf("expected %d Volumes loaded from %s but got %d", nExpectedVolumes, cfg, len(c.Volumes))
+	}
+	if len(c.VolumeMounts) != nExpectedVolumeMounts {
+		t.Fatalf("expected %d VolumeMounts loaded from %s but got %d", nExpectedVolumeMounts, cfg, len(c.VolumeMounts))
+	}
+	if len(c.HostAliases) != nExpectedHostAliases {
+		t.Fatalf("expected %d HostAliases loaded from %s but got %d", nExpectedHostAliases, cfg, len(c.HostAliases))
 	}
 }
 
@@ -187,5 +237,8 @@ func TestGetInjectionConfig(t *testing.T) {
 	}
 	if len(i.VolumeMounts) != 0 {
 		t.Fatalf("expected %d VolumeMounts, but got %d", 0, len(i.VolumeMounts))
+	}
+	if len(i.HostAliases) != 0 {
+		t.Fatalf("expected %d HostAliases, but got %d", 0, len(i.HostAliases))
 	}
 }

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -168,7 +168,7 @@ func TestLoadHostAliasesConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedName := "host-aliases"
-	nExpectedContainers := 2
+	nExpectedContainers := 1
 	nExpectedVolumes := 0
 	nExpectedEnvironmentVars := 2
 	nExpectedVolumeMounts := 0

--- a/internal/pkg/config/watcher/loader_test.go
+++ b/internal/pkg/config/watcher/loader_test.go
@@ -20,6 +20,7 @@ type injectionConfigExpectation struct {
 	envCount         int
 	containerCount   int
 	volumeMountCount int
+	hostAliasCount   int
 }
 
 var (
@@ -32,6 +33,7 @@ var (
 				envCount:         3,
 				containerCount:   0,
 				volumeMountCount: 0,
+				hostAliasCount:   0,
 			},
 		},
 		"configmap-sidecar-test": []injectionConfigExpectation{
@@ -41,6 +43,7 @@ var (
 				envCount:         2,
 				containerCount:   2,
 				volumeMountCount: 0,
+				hostAliasCount:   0,
 			},
 		},
 		"configmap-complex-sidecar": []injectionConfigExpectation{
@@ -50,6 +53,7 @@ var (
 				envCount:         0,
 				containerCount:   4,
 				volumeMountCount: 0,
+				hostAliasCount:   0,
 			},
 		},
 		"configmap-multiple1": []injectionConfigExpectation{
@@ -59,6 +63,7 @@ var (
 				envCount:         3,
 				containerCount:   0,
 				volumeMountCount: 0,
+				hostAliasCount:   0,
 			},
 			injectionConfigExpectation{
 				name:             "sidecar-test",
@@ -66,6 +71,7 @@ var (
 				envCount:         2,
 				containerCount:   2,
 				volumeMountCount: 0,
+				hostAliasCount:   0,
 			},
 		},
 		"configmap-volume-mounts": []injectionConfigExpectation{
@@ -75,6 +81,17 @@ var (
 				envCount:         2,
 				containerCount:   3,
 				volumeMountCount: 1,
+				hostAliasCount:   0,
+			},
+		},
+		"configmap-host-aliases": []injectionConfigExpectation{
+			injectionConfigExpectation{
+				name:             "host-aliases",
+				volumeCount:      0,
+				envCount:         2,
+				containerCount:   1,
+				volumeMountCount: 0,
+				hostAliasCount:   2,
 			},
 		},
 	}
@@ -145,6 +162,9 @@ func TestLoadFromConfigMap(t *testing.T) {
 			}
 			if len(ic.VolumeMounts) != expectedICF.volumeMountCount {
 				t.Fatalf("expected %d volume mounts in %s, but found %d", expectedICF.volumeMountCount, expectedICF.name, len(ic.VolumeMounts))
+			}
+			if len(ic.HostAliases) != expectedICF.hostAliasCount {
+				t.Fatalf("expected %d host aliases in %s, but found %d", expectedICF.hostAliasCount, expectedICF.name, len(ic.HostAliases))
 			}
 			for _, actualIC := range ics {
 				if ic.Name == actualIC.Name {

--- a/internal/pkg/config/watcher/loader_test.go
+++ b/internal/pkg/config/watcher/loader_test.go
@@ -91,7 +91,7 @@ var (
 				envCount:         2,
 				containerCount:   1,
 				volumeMountCount: 0,
-				hostAliasCount:   2,
+				hostAliasCount:   6,
 			},
 		},
 	}

--- a/pkg/server/webhook_test.go
+++ b/pkg/server/webhook_test.go
@@ -21,6 +21,7 @@ var (
 	obj3Missing      = "test/fixtures/k8s/object3-missing.yaml"
 	obj4             = "test/fixtures/k8s/object4.yaml"
 	obj5             = "test/fixtures/k8s/object5.yaml"
+	obj6             = "test/fixtures/k8s/object6.yaml"
 	ignoredNamespace = "test/fixtures/k8s/ignored-namespace-pod.yaml"
 	badSidecar       = "test/fixtures/k8s/bad-sidecar.yaml"
 
@@ -34,7 +35,7 @@ type expectedSidecarConfiguration struct {
 }
 
 func TestLoadConfig(t *testing.T) {
-	expectedNumInjectionConfigs := 4
+	expectedNumInjectionConfigs := 5
 	c, err := config.LoadConfigDirectory(sidecars)
 	if err != nil {
 		t.Error(err)
@@ -65,7 +66,7 @@ func TestLoadConfig(t *testing.T) {
 		{configuration: obj3Missing, expectedSidecar: "", expectedError: ErrMissingRequestAnnotation}, // this one is missing any annotations :)
 		{configuration: obj4, expectedSidecar: "", expectedError: ErrSkipAlreadyInjected},             // this one is already injected, so it should not get injected again
 		{configuration: obj5, expectedSidecar: "volume-mounts"},
-		{configuration: obj5, expectedSidecar: "host-aliases"},
+		{configuration: obj6, expectedSidecar: "host-aliases"},
 		{configuration: ignoredNamespace, expectedSidecar: "", expectedError: ErrSkipIgnoredNamespace},
 		{configuration: badSidecar, expectedSidecar: "this-doesnt-exist", expectedError: ErrRequestedSidecarNotFound},
 	}

--- a/pkg/server/webhook_test.go
+++ b/pkg/server/webhook_test.go
@@ -65,6 +65,7 @@ func TestLoadConfig(t *testing.T) {
 		{configuration: obj3Missing, expectedSidecar: "", expectedError: ErrMissingRequestAnnotation}, // this one is missing any annotations :)
 		{configuration: obj4, expectedSidecar: "", expectedError: ErrSkipAlreadyInjected},             // this one is already injected, so it should not get injected again
 		{configuration: obj5, expectedSidecar: "volume-mounts"},
+		{configuration: obj5, expectedSidecar: "host-aliases"},
 		{configuration: ignoredNamespace, expectedSidecar: "", expectedError: ErrSkipIgnoredNamespace},
 		{configuration: badSidecar, expectedSidecar: "this-doesnt-exist", expectedError: ErrRequestedSidecarNotFound},
 	}

--- a/test/fixtures/k8s/configmap-host-aliases.yaml
+++ b/test/fixtures/k8s/configmap-host-aliases.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-host-aliases
+  namespace: default
+data:
+  test-tumblr1: |
+    name: host-aliases
+    hostAliases:
+      # TODO: add
+    env:
+      - name: DATACENTER
+        value: foo
+      - name: FROM_INJECTOR
+        value: bar
+    containers:
+    - name: sidecar-add-vm
+      image: nginx:1.12.2
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: DATACENTER
+          value: bf2
+      ports:
+        - containerPort: 80

--- a/test/fixtures/k8s/configmap-host-aliases.yaml
+++ b/test/fixtures/k8s/configmap-host-aliases.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: test-host-aliases
-  namespace: default
+  namespace: kube-system
 data:
   test-tumblr1: |
     name: host-aliases
@@ -15,6 +15,15 @@ data:
       - ip: 4.3.2.1
         hostnames:
           - another.domain.com
+      - ip: 4.3.2.1
+        hostnames:
+          - yetanother.domain.com
+      - ip: 2.3.4.5
+        hostnames:
+          - another.domain.com
+      - ip: 4.3.2.1
+      - ip: 4.3.2.1
+        hostnames:
     env:
       - name: DATACENTER
         value: foo

--- a/test/fixtures/k8s/configmap-host-aliases.yaml
+++ b/test/fixtures/k8s/configmap-host-aliases.yaml
@@ -8,7 +8,13 @@ data:
   test-tumblr1: |
     name: host-aliases
     hostAliases:
-      # TODO: add
+      - ip: 1.2.3.4
+        hostnames:
+          - some.domain.com
+          - some.other-domain.com
+      - ip: 4.3.2.1
+        hostnames:
+          - another.domain.com
     env:
       - name: DATACENTER
         value: foo

--- a/test/fixtures/k8s/object5.yaml
+++ b/test/fixtures/k8s/object5.yaml
@@ -1,4 +1,4 @@
-name: object2
+name: object5
 namespace: unittest
 annotations:
   "injector.unittest.com/request": "volume-mounts"

--- a/test/fixtures/k8s/object6.yaml
+++ b/test/fixtures/k8s/object6.yaml
@@ -1,0 +1,4 @@
+name: object6
+namespace: unittest
+annotations:
+  "injector.unittest.com/request": "host-aliases"

--- a/test/fixtures/sidecars/host-aliases.yaml
+++ b/test/fixtures/sidecars/host-aliases.yaml
@@ -1,0 +1,17 @@
+name: volume-mounts
+hostAliases:
+  # TODO: add
+env:
+  - name: DATACENTER
+    value: foo
+  - name: FROM_INJECTOR
+    value: bar
+containers:
+- name: sidecar-add-vm
+  image: nginx:1.12.2
+  imagePullPolicy: IfNotPresent
+  env:
+    - name: DATACENTER
+      value: bf2
+  ports:
+    - containerPort: 80

--- a/test/fixtures/sidecars/host-aliases.yaml
+++ b/test/fixtures/sidecars/host-aliases.yaml
@@ -1,6 +1,12 @@
 name: volume-mounts
 hostAliases:
-  # TODO: add
+  - ip: 1.2.3.4
+    hostnames:
+      - some.domain.com
+      - some.other-domain.com
+  - ip: 4.3.2.1
+    hostnames:
+      - another.domain.com
 env:
   - name: DATACENTER
     value: foo

--- a/test/fixtures/sidecars/host-aliases.yaml
+++ b/test/fixtures/sidecars/host-aliases.yaml
@@ -7,6 +7,15 @@ hostAliases:
   - ip: 4.3.2.1
     hostnames:
       - another.domain.com
+  - ip: 4.3.2.1
+    hostnames:
+      - yetanother.domain.com
+  - ip: 2.3.4.5
+    hostnames:
+      - another.domain.com
+  - ip: 4.3.2.1
+  - ip: 4.3.2.1
+    hostnames:
 env:
   - name: DATACENTER
     value: foo

--- a/test/fixtures/sidecars/host-aliases.yaml
+++ b/test/fixtures/sidecars/host-aliases.yaml
@@ -1,4 +1,4 @@
-name: volume-mounts
+name: host-aliases
 hostAliases:
   - ip: 1.2.3.4
     hostnames:


### PR DESCRIPTION
# What and why?

Add functionality to inject hostAliases, e.g. when certain pods (or injected containers) require access to some external services which are not in internal DNS.
This works similar to the addVolumes functionality.
Merging is not really required, as we just create new entries in /etc/hosts of the pod/containers. So simply adding the entries to the list of hostAliases, even if the same entries already exist is not a big problem (except that it adds a few lines to the YAML).

# Testing Steps

- added unittests as usual
- tested with debian-debug in /examples/kubernetes

# Reviewers

Required reviewers: `@byxorna`
Request reviews from other people you want to review this PR in the "Reviewers" section on the right.

> :warning: this PR must have at least 2 thumbs from the [MAINTAINERS.md](/MAINTAINERS.md) of the project before merging!
