### PR TITLE
fix: don't merge volume mount on sidecar container if it exists

### DIFF
--- a/pkg/server/webhook.go
+++ b/pkg/server/webhook.go
@@ -308,7 +308,7 @@ func mergeVolumeMounts(volumeMounts []corev1.VolumeMount, containers []corev1.Co
 			// check each container for each volume mount by name.
 			// if the container has a matching name, dont override!
 			skip := false
-			for _, origVolumeMount := range c.VolumeDevices {
+			for _, origVolumeMount := range c.VolumeMounts {
 				if origVolumeMount.Name == newVolumeMount.Name {
 					skip = true
 					break


### PR DESCRIPTION
# What and why?

Adding the same volume mounts to sidecar container and to all containers would end up in an error telling that the volume mounts already exist.

# Testing Steps

Using this configuration map we would end up getting the error 
```yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: sidecar-injector-gcsfuse
  namespace: kube-system
  labels:
    app: k8s-sidecar-injector
data:
  gcsfuse: |
    name: gcsfuse
    containers:
    - name: gcsfuse
      image: eu.gcr.io/somerepo/gcsfuse:latest
      imagePullPolicy: IfNotPresent
      securityContext:
        privileged: true
        capabilities:
          add: ["SYS_ADMIN"]
      lifecycle:
        postStart:
          exec:
            command: ["gcsfuse", "-o", "nonempty", "some_bucket", "/home/airflow/gcs/"]
        preStop:
          exec:
            command: ["fusermount", "-zu", "/home/airflow/gcs/"]
      volumeMounts:
      - name: gcsdata
        mountPath: /home/airflow/gcs/
        mountPropagation: Bidirectional
    volumes:
      - name: gcsdata
        emptyDir: {}
    volumeMounts:
      - name: gcsdata
        mountPath: /home/airflow/gcs/
        mountPropagation: HostToContainer
```

# Reviewers

Required reviewers: `@byxorna`
Request reviews from other people you want to review this PR in the "Reviewers" section on the right.

> :warning: this PR must have at least 2 thumbs from the [MAINTAINERS.md](/MAINTAINERS.md) of the project before merging!