### PR TITLE
[Feature] Add initContainer injector

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -30,11 +30,12 @@ var (
 
 // InjectionConfig is a specific instance of a injected config, for a given annotation
 type InjectionConfig struct {
-	Name         string               `json:"name"`
-	Containers   []corev1.Container   `json:"containers"`
-	Volumes      []corev1.Volume      `json:"volumes"`
-	Environment  []corev1.EnvVar      `json:"env"`
-	VolumeMounts []corev1.VolumeMount `json:"volumeMounts"`
+	Name           string               `json:"name"`
+	Containers     []corev1.Container   `json:"containers"`
+	InitContainers []corev1.Container   `json:"initContainers"`
+	Volumes        []corev1.Volume      `json:"volumes"`
+	Environment    []corev1.EnvVar      `json:"env"`
+	VolumeMounts   []corev1.VolumeMount `json:"volumeMounts"`
 }
 
 // Config is a struct indicating how a given injection should be configured

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -12,10 +12,11 @@ var (
 	complicatedConfig = sidecars + "/complex-sidecar.yaml"
 	env1              = sidecars + "/env1.yaml"
 	volumeMounts      = sidecars + "/volume-mounts.yaml"
+	initSidecar       = sidecars + "/init-sidecar.yaml"
 )
 
 func TestLoadConfig(t *testing.T) {
-	expectedNumInjectionsConfig := 4
+	expectedNumInjectionsConfig := 5
 	c, err := LoadConfigDirectory(sidecars)
 	if err != nil {
 		t.Fatal(err)
@@ -144,13 +145,47 @@ func TestLoadVolumeMountsConfig(t *testing.T) {
 	}
 }
 
+func TestLoadInitSidecarConfig(t *testing.T) {
+	cfg := volumeMounts
+	c, err := LoadInjectionConfigFromFilePath(initSidecar)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedName := "init-sidecar"
+	nExpectedContainers := 0
+	nExpectedVolumes := 0
+	nExpectedEnvironmentVars := 0
+	nExpectedVolumeMounts := 0
+	nExpectedInitContainers := 1
+
+	if c.Name != expectedName {
+		t.Fatalf("expected %s Name loaded from %s but got %s", expectedName, cfg, c.Name)
+	}
+	if len(c.Environment) != nExpectedEnvironmentVars {
+		t.Fatalf("expected %d EnvVars loaded from %s but got %d", nExpectedEnvironmentVars, cfg, len(c.Environment))
+	}
+	if len(c.Containers) != nExpectedContainers {
+		t.Fatalf("expected %d Containers loaded from %s but got %d", nExpectedContainers, cfg, len(c.Containers))
+	}
+	if len(c.Volumes) != nExpectedVolumes {
+		t.Fatalf("expected %d Volumes loaded from %s but got %d", nExpectedVolumes, cfg, len(c.Volumes))
+	}
+	if len(c.VolumeMounts) != nExpectedVolumeMounts {
+		t.Fatalf("expected %d VolumeMounts loaded from %s but got %d", nExpectedVolumeMounts, cfg, len(c.VolumeMounts))
+	}
+
+	if len(c.InitContainers) != nExpectedInitContainers {
+		t.Fatalf("expected %d InitContainers loaded from %s but got %d", nExpectedInitContainers, cfg, len(c.InitContainers))
+	}
+}
+
 func TestHasInjectionConfig(t *testing.T) {
 	c, err := LoadConfigDirectory(sidecars)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	for _, k := range []string{"sidecar-test", "complex-sidecar"} {
+	for _, k := range []string{"sidecar-test", "complex-sidecar", "init-sidecar"} {
 		if !c.HasInjectionConfig(k) {
 			t.Fatalf("%s should have included %s but did not", cfg1, k)
 		}

--- a/pkg/server/webhook.go
+++ b/pkg/server/webhook.go
@@ -325,19 +325,19 @@ func mergeVolumeMounts(volumeMounts []corev1.VolumeMount, containers []corev1.Co
 
 func updateAnnotations(target map[string]string, added map[string]string) (patch []patchOperation) {
 	for key, value := range added {
+		keyEscaped := strings.Replace(key, "/", "~1", -1)
+
 		if target == nil || target[key] == "" {
 			target = map[string]string{}
 			patch = append(patch, patchOperation{
-				Op:   "add",
-				Path: "/metadata/annotations",
-				Value: map[string]string{
-					key: value,
-				},
+				Op:    "add",
+				Path:  "/metadata/annotations/" + keyEscaped,
+				Value: value,
 			})
 		} else {
 			patch = append(patch, patchOperation{
 				Op:    "replace",
-				Path:  "/metadata/annotations/" + key,
+				Path:  "/metadata/annotations/" + keyEscaped,
 				Value: value,
 			})
 		}
@@ -353,8 +353,11 @@ func createPatch(pod *corev1.Pod, inj *config.InjectionConfig, annotations map[s
 	// this mutates inj.Containers with our environment vars
 	mutatedInjectedContainers := mergeEnvVars(inj.Environment, inj.Containers)
 	mutatedInjectedContainers = mergeVolumeMounts(inj.VolumeMounts, mutatedInjectedContainers)
+
 	// next, patch containers with our injected containers
 	patch = append(patch, addContainers(pod.Spec.Containers, mutatedInjectedContainers, "/spec/containers")...)
+	// next, patch initContainers with our injected initContainers
+	patch = append(patch, addContainers(pod.Spec.InitContainers, inj.InitContainers, "/spec/initContainers")...)
 	// now, patch all existing containers with the env vars and volume mounts
 	patch = append(patch, setEnvironment(pod.Spec.Containers, inj.Environment)...)
 	patch = append(patch, addVolumeMounts(pod.Spec.Containers, inj.VolumeMounts)...)
@@ -404,7 +407,9 @@ func (whsvr *WebhookServer) mutate(ar *v1beta1.AdmissionReview) *v1beta1.Admissi
 
 	// Workaround: https://github.com/kubernetes/kubernetes/issues/57982
 	applyDefaultsWorkaround(injectionConfig.Containers, injectionConfig.Volumes)
-	annotations := map[string]string{config.InjectionStatusAnnotation: StatusInjected}
+
+	annotations := map[string]string{}
+	annotations[config.InjectionStatusAnnotation] = StatusInjected
 	patchBytes, err := createPatch(&pod, injectionConfig, annotations)
 	if err != nil {
 		injectionCounter.With(prometheus.Labels{"status": "error", "reason": "patching_error", "requested": injectionKey}).Inc()

--- a/pkg/server/webhook_test.go
+++ b/pkg/server/webhook_test.go
@@ -21,6 +21,7 @@ var (
 	obj3Missing      = "test/fixtures/k8s/object3-missing.yaml"
 	obj4             = "test/fixtures/k8s/object4.yaml"
 	obj5             = "test/fixtures/k8s/object5.yaml"
+	obj6             = "test/fixtures/k8s/object6.yaml"
 	ignoredNamespace = "test/fixtures/k8s/ignored-namespace-pod.yaml"
 	badSidecar       = "test/fixtures/k8s/bad-sidecar.yaml"
 
@@ -34,7 +35,7 @@ type expectedSidecarConfiguration struct {
 }
 
 func TestLoadConfig(t *testing.T) {
-	expectedNumInjectionConfigs := 4
+	expectedNumInjectionConfigs := 5
 	c, err := config.LoadConfigDirectory(sidecars)
 	if err != nil {
 		t.Error(err)
@@ -65,6 +66,7 @@ func TestLoadConfig(t *testing.T) {
 		{configuration: obj3Missing, expectedSidecar: "", expectedError: ErrMissingRequestAnnotation}, // this one is missing any annotations :)
 		{configuration: obj4, expectedSidecar: "", expectedError: ErrSkipAlreadyInjected},             // this one is already injected, so it should not get injected again
 		{configuration: obj5, expectedSidecar: "volume-mounts"},
+		{configuration: obj6, expectedSidecar: "init-sidecar"},
 		{configuration: ignoredNamespace, expectedSidecar: "", expectedError: ErrSkipIgnoredNamespace},
 		{configuration: badSidecar, expectedSidecar: "this-doesnt-exist", expectedError: ErrRequestedSidecarNotFound},
 	}

--- a/test/fixtures/k8s/object6.yaml
+++ b/test/fixtures/k8s/object6.yaml
@@ -1,0 +1,4 @@
+name: object2
+namespace: unittest
+annotations:
+  "injector.unittest.com/request": "init-sidecar"

--- a/test/fixtures/sidecars/init-sidecar.yaml
+++ b/test/fixtures/sidecars/init-sidecar.yaml
@@ -1,0 +1,18 @@
+---
+name: init-sidecar
+initContainers:
+  - name: foo
+    image: some/container:1.2.3
+    command: ["entrypoint.sh"]
+    livenessProbe:
+      httpGet:
+        path: /
+        port: 420
+      initialDelaySeconds: 3
+      periodSeconds: 10
+    resources:
+      requests:
+        cpu: "0.5"
+        memory: "1Gi"
+      limits:
+        cpu: "1.0"


### PR DESCRIPTION
# What and why?

I added support for injecting init containers. We are using it for injecting tools like New Relic in to our applications

There is also a small fix in the updateAnnotations function to escape '/' in annotation names so that the json patch works without overwriting existing pod annotations.

# Testing Steps

- Added unit tests for this feature (`make test`)

# Reviewers

Required reviewers: `@byxorna`
Request reviews from other people you want to review this PR in the "Reviewers" section on the right.

> :warning: this PR must have at least 2 thumbs from the [MAINTAINERS.md](/MAINTAINERS.md) of the project before merging!
