### PR TITLE
lower bucket size for latency measurements

### DIFF
--- a/pkg/server/webhook.go
+++ b/pkg/server/webhook.go
@@ -59,7 +59,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "http_request_duration_seconds",
 			Help:    "A histogram of latencies for requests.",
-			Buckets: []float64{.1, .25, .5, 1, 2.5, 5, 10},
+			Buckets: []float64{.001, .01, .05, .1, .5, 1, 5},
 		},
 		[]string{"handler", "method"},
 	)


### PR DESCRIPTION
# What and why?

The latency buckets we were using were _way_ too large to provide effective measurement. Lets make these smaller :)

# Testing Steps

Just let travis test for us :)

# Reviewers

Required reviewers: `@byxorna`
Request reviews from other people you want to review this PR in the "Reviewers" section on the right.

> :warning: this PR must have at least 2 thumbs from the [MAINTAINERS.md](/MAINTAINERS.md) of the project before merging!
