### PR TITLE
Fix panic when creating the ConfigMap watch fails

### DIFF
--- a/internal/pkg/config/watcher/watcher.go
+++ b/internal/pkg/config/watcher/watcher.go
@@ -103,10 +103,10 @@ func (c *K8sConfigMapWatcher) Watch(ctx context.Context, notifyMe chan<- interfa
 	watcher, err := c.client.ConfigMaps(c.Namespace).Watch(metav1.ListOptions{
 		LabelSelector: mapStringStringToLabelSelector(c.ConfigMapLabels),
 	})
-	defer watcher.Stop()
 	if err != nil {
 		return fmt.Errorf("unable to create watcher (possible serviceaccount RBAC/ACL failure?): %s", err.Error())
 	}
+	defer watcher.Stop()
 	for {
 		select {
 		case e, ok := <-watcher.ResultChan():


### PR DESCRIPTION
# What and why?

`(*K8sConfigMapWatcher).Watch` panics when creating the ConfigMap watcher fails, as it attempts to call `Stop()` on `nil` (returned by client-go) when creating the watch returns an error.  This is pretty simply fixed by only deferring the call once the error check has occurred. Fixing this issue will cause errors returned from the Kubernetes API to be properly logged, rather than causing a panic.

# Testing Steps

I added a test for this behavior, and confirmed that the test causes a panic without the relevant code change.

- [X] Added unit tests for this feature (`make test`)

# Reviewers

Required reviewers: `@byxorna`