### PR TITLE
fix MutatingWebhookConfiguration replace env value bug

### DIFF
--- a/examples/kubernetes/mutating-webhook-configuration.yaml
+++ b/examples/kubernetes/mutating-webhook-configuration.yaml
@@ -22,4 +22,4 @@ webhooks:
       namespace: "kube-system"
       path: "/mutate"   # what /url/slug to send requests at
     # See README.md for how this was generated!
-    caBundle: "!!! your base64 encoded cabundle here !!!"
+    caBundle: "__CA_BUNDLE_BASE64__"


### PR DESCRIPTION
int flie tls.md
'''
Now, take this data and set it into the mutating webhook config as the caBundle: value.

$ sed -i '' -e "s|__CA_BUNDLE_BASE64__|$CABUNDLE_BASE64|g" examples/kubernetes/mutating-webhook-configuration.yaml
'''
so mutating-webhook-configuration.yaml shoud use '__CA_BUNDLE_BASE64__' variable

