### PR TITLE
Document configuration name error

### DIFF
--- a/docs/sidecar-configuration-format.md
+++ b/docs/sidecar-configuration-format.md
@@ -15,7 +15,7 @@ A sidecar configuration looks like:
 # Each InjectionConfig is a struct that adheres to kubernetes' volume and containers
 # spec. Any volumes injected are scoped to the namespace that the
 # resource exists within
-name: "test"
+name: "tumblr-php"
 containers:
 # we inject a nginx container
 - name: sidecar-nginx


### PR DESCRIPTION
documents comment:
# sidecar configs are identified by a requesting
# annotation, like:
# "injector.tumblr.com/request=tumblr-php"
# the "name: tumblr-php" must match a configuration below; 

but configuration is
name: "test"