### PR TITLE
add annotation namespace

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,7 @@ TLS_CERT_FILE="${TLS_CERT_FILE:-/var/lib/secrets/cert.crt}"
 TLS_KEY_FILE="${TLS_KEY_FILE:-/var/lib/secrets/cert.key}"
 CONFIGMAP_LABELS="${CONFIGMAP_LABELS:-app=k8s-sidecar-injector}"
 CONFIGMAP_NAMESPACE="${CONFIGMAP_NAMESPACE:-}"
+ANNOTATION_NAMESPACE="${ANNOTATION_NAMESPACE:-injector.tumblr.com}"
 LOG_LEVEL="${LOG_LEVEL:-2}"
 echo "k8s-sidecar-injector starting at $(date) with TLS_PORT=${TLS_PORT} CONFIG_DIR=${CONFIG_DIR} TLS_CERT_FILE=${TLS_CERT_FILE} TLS_KEY_FILE=${TLS_KEY_FILE}"
 set -x
@@ -19,4 +20,5 @@ exec k8s-sidecar-injector \
   --tls-key-file="${TLS_KEY_FILE}" \
   --configmap-labels="${CONFIGMAP_LABELS}" \
   --configmap-namespace="${CONFIGMAP_NAMESPACE}" \
+  --annotation-namespace="${ANNOTATION_NAMESPACE}" \
   "$@"


### PR DESCRIPTION
1、current deployment only has livenessProbe，but don't have readiness
2、configmap read config form installation config, so it's better to config this variable
3、execurte need ruby env, so tell reader to install ruby first