### PR TITLE
Correctly handle inheritance with ServiceAccounts

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -59,7 +59,7 @@ func (c *InjectionConfig) String() string {
 		inheritsString = fmt.Sprintf(" (inherits %s)", c.Inherits)
 	}
 
-	return fmt.Sprintf("%s%s: %d containers, %d init containers, %d volumes, %d environment vars, %d volume mounts, %d host aliases",
+	return fmt.Sprintf("%s%s: %d containers, %d init containers, %d volumes, %d environment vars, %d volume mounts, %d host aliases, serviceAccount %v",
 		c.FullName(),
 		inheritsString,
 		len(c.Containers),
@@ -67,7 +67,8 @@ func (c *InjectionConfig) String() string {
 		len(c.Volumes),
 		len(c.Environment),
 		len(c.VolumeMounts),
-		len(c.HostAliases))
+		len(c.HostAliases),
+		c.ServiceAccountName)
 }
 
 // Version returns the parsed version of this injection config. If no version is specified,

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -266,6 +266,11 @@ func (base *InjectionConfig) Merge(child *InjectionConfig) error {
 		}
 	}
 
+	// merge serviceAccount settings to the left
+	if child.ServiceAccountName != "" {
+		base.ServiceAccountName = child.ServiceAccountName
+	}
+
 	return nil
 }
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -59,7 +59,11 @@ func (c *InjectionConfig) String() string {
 		inheritsString = fmt.Sprintf(" (inherits %s)", c.Inherits)
 	}
 
-	return fmt.Sprintf("%s%s: %d containers, %d init containers, %d volumes, %d environment vars, %d volume mounts, %d host aliases, serviceAccount %v",
+	saString := ""
+	if c.ServiceAccountName != "" {
+		saString = fmt.Sprintf(", serviceAccountName %s", c.ServiceAccountName)
+	}
+	return fmt.Sprintf("%s%s: %d containers, %d init containers, %d volumes, %d environment vars, %d volume mounts, %d host aliases%s",
 		c.FullName(),
 		inheritsString,
 		len(c.Containers),
@@ -68,7 +72,7 @@ func (c *InjectionConfig) String() string {
 		len(c.Environment),
 		len(c.VolumeMounts),
 		len(c.HostAliases),
-		c.ServiceAccountName)
+		saString)
 }
 
 // Version returns the parsed version of this injection config. If no version is specified,

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -144,7 +144,7 @@ var (
 			VolumeMountCount:   0,
 			HostAliasCount:     0,
 			InitContainerCount: 0,
-			ServiceAccount:     "fuck",
+			ServiceAccount:     "someaccount",
 		},
 	}
 )
@@ -199,6 +199,9 @@ func TestGoodConfigs(t *testing.T) {
 		}
 		if len(c.InitContainers) != testConfig.InitContainerCount {
 			t.Fatalf("expected %d InitContainers loaded from %s but got %d", testConfig.InitContainerCount, testConfig.Path, len(c.InitContainers))
+		}
+		if c.ServiceAccountName != testConfig.ServiceAccount {
+			t.Fatalf("expected ServiceAccountName %s, but got %s", testConfig.ServiceAccount, c.ServiceAccountName)
 		}
 	}
 }
@@ -257,5 +260,8 @@ func TestGetInjectionConfig(t *testing.T) {
 	}
 	if len(i.InitContainers) != cfg.InitContainerCount {
 		t.Fatalf("expected %d InitContainers, but got %d", cfg.InitContainerCount, len(i.InitContainers))
+	}
+	if i.ServiceAccountName != cfg.ServiceAccount {
+		t.Fatalf("expected ServiceAccountName %s, but got %s", cfg.ServiceAccount, i.ServiceAccountName)
 	}
 }

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -146,6 +146,20 @@ var (
 			InitContainerCount: 0,
 			ServiceAccount:     "someaccount",
 		},
+		// we found that inheritance could cause the loading of the ServiceAccount
+		// to fail, so we test explicitly for this case.
+		"service-account-with-inheritance": testhelper.ConfigExpectation{
+			Name:               "service-account-inherits-env1",
+			Version:            "latest",
+			Path:               fixtureSidecarsDir + "/service-account-with-inheritance.yaml",
+			EnvCount:           3,
+			ContainerCount:     0,
+			VolumeCount:        0,
+			VolumeMountCount:   0,
+			HostAliasCount:     0,
+			InitContainerCount: 0,
+			ServiceAccount:     "someaccount",
+		},
 	}
 )
 

--- a/pkg/server/webhook.go
+++ b/pkg/server/webhook.go
@@ -431,9 +431,13 @@ func createPatch(pod *corev1.Pod, inj *config.InjectionConfig, annotations map[s
 	patch = append(patch, addContainers(pod.Spec.InitContainers, mutatedInjectedInitContainers, "/spec/initContainers")...)
 	patch = append(patch, addHostAliases(pod.Spec.HostAliases, inj.HostAliases, "/spec/hostAliases")...)
 	patch = append(patch, addVolumes(pod.Spec.Volumes, inj.Volumes, "/spec/volumes")...)
+
+	glog.Infof("Injection ServiceAccountName=%s pod.Spec.ServiceAccountName=%s pod.Spec.DeprecatedServiceAccount=%s", inj.ServiceAccountName, pod.Spec.ServiceAccountName, pod.Spec.DeprecatedServiceAccount)
 	if inj.ServiceAccountName != "" && (pod.Spec.ServiceAccountName == "" || pod.Spec.ServiceAccountName == "default") {
 		// only override the serviceaccount name if not set in the pod spec
-		patch = append(patch, setServiceAccount(inj.ServiceAccountName, "/spec")...)
+		p := setServiceAccount(inj.ServiceAccountName, "/spec")
+		glog.Infof("Patching serviceAccountName %+v", p)
+		patch = append(patch, p...)
 	}
 
 	// last but not least, set annotations

--- a/pkg/server/webhook.go
+++ b/pkg/server/webhook.go
@@ -432,12 +432,9 @@ func createPatch(pod *corev1.Pod, inj *config.InjectionConfig, annotations map[s
 	patch = append(patch, addHostAliases(pod.Spec.HostAliases, inj.HostAliases, "/spec/hostAliases")...)
 	patch = append(patch, addVolumes(pod.Spec.Volumes, inj.Volumes, "/spec/volumes")...)
 
-	glog.Infof("Injection ServiceAccountName=%s pod.Spec.ServiceAccountName=%s pod.Spec.DeprecatedServiceAccount=%s", inj.ServiceAccountName, pod.Spec.ServiceAccountName, pod.Spec.DeprecatedServiceAccount)
 	if inj.ServiceAccountName != "" && (pod.Spec.ServiceAccountName == "" || pod.Spec.ServiceAccountName == "default") {
 		// only override the serviceaccount name if not set in the pod spec
-		p := setServiceAccount(inj.ServiceAccountName, "/spec")
-		glog.Infof("Patching serviceAccountName %+v", p)
-		patch = append(patch, p...)
+		patch = append(patch, setServiceAccount(inj.ServiceAccountName, "/spec")...)
 	}
 
 	// last but not least, set annotations

--- a/pkg/server/webhook.go
+++ b/pkg/server/webhook.go
@@ -431,7 +431,7 @@ func createPatch(pod *corev1.Pod, inj *config.InjectionConfig, annotations map[s
 	patch = append(patch, addContainers(pod.Spec.InitContainers, mutatedInjectedInitContainers, "/spec/initContainers")...)
 	patch = append(patch, addHostAliases(pod.Spec.HostAliases, inj.HostAliases, "/spec/hostAliases")...)
 	patch = append(patch, addVolumes(pod.Spec.Volumes, inj.Volumes, "/spec/volumes")...)
-	if inj.ServiceAccountName != "" && pod.Spec.ServiceAccountName == "" {
+	if inj.ServiceAccountName != "" && (pod.Spec.ServiceAccountName == "" || pod.Spec.ServiceAccountName == "default") {
 		// only override the serviceaccount name if not set in the pod spec
 		patch = append(patch, setServiceAccount(inj.ServiceAccountName, "/spec")...)
 	}

--- a/test/fixtures/k8s/admissioncontrol/patch/service-account-set-default.json
+++ b/test/fixtures/k8s/admissioncontrol/patch/service-account-set-default.json
@@ -1,0 +1,12 @@
+[
+   {
+      "op": "replace",
+      "path": "/spec/serviceAccountName",
+      "value": "someaccount"
+   },
+   {
+      "op" : "add",
+      "path" : "/metadata/annotations/injector.unittest.com~1status",
+      "value" : "injected"
+   }
+]

--- a/test/fixtures/k8s/admissioncontrol/request/service-account-set-default.yaml
+++ b/test/fixtures/k8s/admissioncontrol/request/service-account-set-default.yaml
@@ -1,0 +1,10 @@
+---
+# this is an AdmissionRequest object
+# https://godoc.org/k8s.io/api/admission/v1beta1#AdmissionRequest
+object:
+  metadata:
+    annotations:
+      injector.unittest.com/request: "service-account"
+  spec:
+    serviceAccountName: "default" # this should get replaced
+    containers: []

--- a/test/fixtures/sidecars/service-account-with-inheritance.yaml
+++ b/test/fixtures/sidecars/service-account-with-inheritance.yaml
@@ -1,0 +1,4 @@
+---
+name: service-account-inherits-env1
+inherits: env1.yaml
+serviceAccountName: someaccount


### PR DESCRIPTION
# What and why?

I found a but that would cause an injection config that uses inheritance to not correctly inherit the ServiceAccountName. Additionally, I accidentally would skip injecting the serviceAccount if the pod admission request was not empty, but this is bad because the default ServiceAccountName is called `"default"`. 

# Testing Steps

- [x] Added unit tests for this feature (`make test`)

# Reviewers

Required reviewers: @byxorna @defect @komapa @tumblr/k8s 
Request reviews from other people you want to review this PR in the "Reviewers" section on the right.

> :warning: this PR must have at least 2 thumbs from the [MAINTAINERS.md](/MAINTAINERS.md) of the project before merging!
