### PR TITLE
make sure we remove any volumeMounts that were precreated when inject…

### DIFF
--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -160,6 +160,22 @@ var (
 			InitContainerCount: 0,
 			ServiceAccount:     "someaccount",
 		},
+		// also, if we inject a serviceAccount and any container has a VolumeMount
+		// with a mountPath of /var/run/secrets/kubernetes.io/serviceaccount, we
+		// must remove it, to allow the ServiceAccountController to inject the
+		// appropriate token volume
+		"service-account-default-token": testhelper.ConfigExpectation{
+			Name:               "service-account-default-token",
+			Version:            "latest",
+			Path:               fixtureSidecarsDir + "/service-account-default-token.yaml",
+			EnvCount:           0,
+			ContainerCount:     0,
+			VolumeCount:        0,
+			VolumeMountCount:   0,
+			HostAliasCount:     0,
+			InitContainerCount: 0,
+			ServiceAccount:     "someaccount",
+		},
 	}
 )
 

--- a/pkg/server/webhook.go
+++ b/pkg/server/webhook.go
@@ -26,9 +26,10 @@ const (
 )
 
 var (
-	runtimeScheme = runtime.NewScheme()
-	codecs        = serializer.NewCodecFactory(runtimeScheme)
-	deserializer  = codecs.UniversalDeserializer()
+	serviceAccountTokenMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
+	runtimeScheme                = runtime.NewScheme()
+	codecs                       = serializer.NewCodecFactory(runtimeScheme)
+	deserializer                 = codecs.UniversalDeserializer()
 
 	// (https://github.com/kubernetes/kubernetes/issues/57982)
 	defaulter = runtime.ObjectDefaulter(runtimeScheme)
@@ -322,7 +323,7 @@ func setServiceAccount(initContainers []corev1.Container, containers []corev1.Co
 	//    mountPath: /var/run/secrets/kubernetes.io/serviceaccount
 	for icIndex, ic := range initContainers {
 		for vmIndex, vm := range ic.VolumeMounts {
-			if vm.MountPath == "/var/run/secrets/kubernetes.io/serviceaccount" {
+			if vm.MountPath == serviceAccountTokenMountPath {
 				patch = append(patch, patchOperation{
 					Op:   "remove",
 					Path: fmt.Sprintf("%s/initContainers/%d/volumeMounts/%d", basePath, icIndex, vmIndex),
@@ -332,7 +333,7 @@ func setServiceAccount(initContainers []corev1.Container, containers []corev1.Co
 	}
 	for cIndex, c := range containers {
 		for vmIndex, vm := range c.VolumeMounts {
-			if vm.MountPath == "/var/run/secrets/kubernetes.io/serviceaccount" {
+			if vm.MountPath == serviceAccountTokenMountPath {
 				patch = append(patch, patchOperation{
 					Op:   "remove",
 					Path: fmt.Sprintf("%s/containers/%d/volumeMounts/%d", basePath, cIndex, vmIndex),

--- a/pkg/server/webhook_test.go
+++ b/pkg/server/webhook_test.go
@@ -63,6 +63,7 @@ var (
 		{name: "service-account", allowed: true, patchExpected: true},
 		{name: "service-account-already-set", allowed: true, patchExpected: true},
 		{name: "service-account-set-default", allowed: true, patchExpected: true},
+		{name: "service-account-default-token", allowed: true, patchExpected: true},
 	}
 	sidecarConfigs, _           = filepath.Glob(path.Join(sidecars, "*.yaml"))
 	expectedNumInjectionConfigs = len(sidecarConfigs)

--- a/test/fixtures/k8s/admissioncontrol/patch/service-account-default-token.json
+++ b/test/fixtures/k8s/admissioncontrol/patch/service-account-default-token.json
@@ -1,0 +1,20 @@
+[
+   {
+      "op": "replace",
+      "path": "/spec/serviceAccountName",
+      "value": "someaccount"
+   },
+   {
+      "op": "remove",
+      "path": "/spec/initContainers/0/volumeMounts/0"
+   },
+   {
+      "op": "remove",
+      "path": "/spec/containers/1/volumeMounts/1"
+   },
+   {
+      "op" : "add",
+      "path" : "/metadata/annotations/injector.unittest.com~1status",
+      "value" : "injected"
+   }
+]

--- a/test/fixtures/k8s/admissioncontrol/request/service-account-default-token.yaml
+++ b/test/fixtures/k8s/admissioncontrol/request/service-account-default-token.yaml
@@ -1,0 +1,48 @@
+---
+# this is an AdmissionRequest object
+# https://godoc.org/k8s.io/api/admission/v1beta1#AdmissionRequest
+object:
+  metadata:
+    annotations:
+      injector.unittest.com/request: "service-account-default-token"
+  spec:
+    serviceAccountName: "default" # this should get replaced
+    volumes:
+      - name: bogusvolume
+        configMap:
+          name: config-production
+          defaultMode: 420
+      - name: default-token-wlfz2
+        secret:
+          secretName: default-token-wlfz2
+          defaultMode: 420
+    initContainers:
+      - name: init-ctr1-with-token
+        volumeMounts:
+        # this volume mount must be removed, because
+        # by default, a serviceAccount will mount its token,
+        # preventing the injected serviceAccount from settings up its mount
+        - name: default-token-wlfz2
+          readOnly: true
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      - name: init-ctr2
+        volumeMounts: []
+    containers:
+      - name: ctr1
+        volumeMounts:
+        - name: bogusvolume
+          readOnly: true
+          mountPath: /app/config
+      - name: ctr2-with-token
+        volumeMounts:
+        - name: bogusvolume
+          readOnly: true
+          mountPath: /app/config
+        # this volume mount must be removed, because
+        # by default, a serviceAccount will mount its token,
+        # preventing the injected serviceAccount from settings up its mount
+        - name: default-token-wlfz2
+          readOnly: true
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      - name: ctr3
+        volumeMounts: []

--- a/test/fixtures/sidecars/service-account-default-token.yaml
+++ b/test/fixtures/sidecars/service-account-default-token.yaml
@@ -1,0 +1,3 @@
+---
+name: service-account-default-token
+serviceAccountName: someaccount


### PR DESCRIPTION
…ing a serviceAccount

# What and why?

I missed one edge case in https://github.com/tumblr/k8s-sidecar-injector/pull/39 - any containers that exist in the admission requested pod before we inject a serviceAccount will already have had any VolumeMounts for the serviceaccount's token created, when `automountServiceAccountToken:true`. This is a bit annoying, and causes users of ServiceAccount injections to have original containers continue to use the `default-token-*` mount, whereas injected containers use the correct `${serviceAccountName}-token-*` mount that is added by the ServiceAccountController after processing the MWAC injection.

# Testing Steps

- [x] Added unit tests for this feature (`make test`)

# Reviewers

Required reviewers: `@byxorna`
Request reviews from other people you want to review this PR in the "Reviewers" section on the right.

> :warning: this PR must have at least 2 thumbs from the [MAINTAINERS.md](/MAINTAINERS.md) of the project before merging!
