### PR TITLE
Use name and namespace from the request

### DIFF
--- a/pkg/server/errors.go
+++ b/pkg/server/errors.go
@@ -5,8 +5,6 @@ import (
 )
 
 var (
-	// ErrSkipIgnoredNamespace ...
-	ErrSkipIgnoredNamespace = fmt.Errorf("Skipping pod in ignored namespace")
 	// ErrSkipAlreadyInjected ...
 	ErrSkipAlreadyInjected = fmt.Errorf("Skipping pod that has already been injected")
 	// ErrMissingRequestAnnotation ...
@@ -20,8 +18,6 @@ var (
 func GetErrorReason(err error) string {
 	var reason string
 	switch err {
-	case ErrSkipIgnoredNamespace:
-		reason = "ignored_namespace"
 	case ErrSkipAlreadyInjected:
 		reason = "already_injected"
 	case ErrMissingRequestAnnotation:

--- a/pkg/server/webhook.go
+++ b/pkg/server/webhook.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -136,15 +137,7 @@ func (whsvr *WebhookServer) requestAnnotationKey() string {
 
 // Check whether the target resoured need to be mutated. returns the canonicalized full name of the injection config
 // if found, or an error if not.
-func (whsvr *WebhookServer) getSidecarConfigurationRequested(ignoredList []string, metadata *metav1.ObjectMeta) (string, error) {
-	// skip special kubernetes system namespaces
-	for _, namespace := range ignoredList {
-		if metadata.Namespace == namespace {
-			glog.Infof("Pod %s/%s should skip injection due to ignored namespace", metadata.Name, metadata.Namespace)
-			return "", ErrSkipIgnoredNamespace
-		}
-	}
-
+func (whsvr *WebhookServer) getSidecarConfigurationRequested(metadata *metav1.ObjectMeta) (string, error) {
 	annotations := metadata.GetAnnotations()
 	if annotations == nil {
 		annotations = map[string]string{}
@@ -155,23 +148,19 @@ func (whsvr *WebhookServer) getSidecarConfigurationRequested(ignoredList []strin
 
 	status, ok := annotations[statusAnnotationKey]
 	if ok && strings.ToLower(status) == StatusInjected {
-		glog.Infof("Pod %s/%s annotation %s=%s indicates injection already satisfied, skipping", metadata.Namespace, metadata.Name, statusAnnotationKey, status)
-		return "", ErrSkipAlreadyInjected
+		return "", fmt.Errorf("%w: annotation %s=%s indicates injection already satisfied", ErrSkipAlreadyInjected, statusAnnotationKey, status)
 	}
 
 	// determine whether to perform mutation based on annotation for the target resource
 	requestedInjection, ok := annotations[requestAnnotationKey]
 	if !ok {
-		glog.Infof("Pod %s/%s annotation %s is missing, skipping injection", metadata.Namespace, metadata.Name, requestAnnotationKey)
-		return "", ErrMissingRequestAnnotation
+		return "", fmt.Errorf("%w: %s", ErrMissingRequestAnnotation, requestAnnotationKey)
 	}
 	ic, err := whsvr.Config.GetInjectionConfig(requestedInjection)
 	if err != nil {
-		glog.Errorf("Mutation policy for pod %s/%s: %v", metadata.Namespace, metadata.Name, err)
-		return "", ErrRequestedSidecarNotFound
+		return "", fmt.Errorf("%w: %s", ErrRequestedSidecarNotFound, requestedInjection)
 	}
 
-	glog.Infof("Pod %s/%s annotation %s=%s requesting sidecar config %s", metadata.Namespace, metadata.Name, requestAnnotationKey, requestedInjection, ic.FullName())
 	return ic.FullName(), nil
 }
 
@@ -510,16 +499,42 @@ func (whsvr *WebhookServer) mutate(req *v1beta1.AdmissionRequest) *v1beta1.Admis
 	glog.Infof("AdmissionReview for Kind=%s, Namespace=%s Name=%s (%s) UID=%s patchOperation=%s UserInfo=%s",
 		req.Kind, req.Namespace, req.Name, pod.Name, req.UID, req.Operation, req.UserInfo)
 
+	// the admission request may not provide a name in the request itself or in
+	// the metadata of the object
+	podName := "<pod name not available>"
+	if pod.Name != "" {
+		podName = pod.Name
+	} else if req.Name != "" {
+		podName = req.Name
+	}
+
+	// skip special kubernetes system namespaces
+	for _, namespace := range ignoredNamespaces {
+		if req.Namespace == namespace {
+			glog.Infof("Skipping mutation of %s/%s: %s", req.Namespace, podName, "Skipping pod in ignored namespace")
+			injectionCounter.With(prometheus.Labels{"status": "skipped", "reason": "ignored_namespace", "requested": ""}).Inc()
+			return &v1beta1.AdmissionResponse{
+				Allowed: true,
+			}
+		}
+	}
+
 	// determine whether to perform mutation
-	injectionKey, err := whsvr.getSidecarConfigurationRequested(ignoredNamespaces, &pod.ObjectMeta)
+	injectionKey, err := whsvr.getSidecarConfigurationRequested(&pod.ObjectMeta)
 	if err != nil {
-		glog.Infof("Skipping mutation of %s/%s: %v", pod.Namespace, pod.Name, err)
+		if errors.Is(err, ErrRequestedSidecarNotFound) {
+			glog.Errorf("Mutation policy for pod %s/%s: %v", req.Namespace, podName, err)
+		} else {
+			glog.Infof("Skipping mutation of %s/%s: %v", req.Namespace, podName, err)
+		}
 		reason := GetErrorReason(err)
 		injectionCounter.With(prometheus.Labels{"status": "skipped", "reason": reason, "requested": injectionKey}).Inc()
 		return &v1beta1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
+
+	glog.Infof("Pod %s/%s requesting sidecar config %s", req.Namespace, podName, injectionKey)
 
 	injectionConfig, err := whsvr.Config.GetInjectionConfig(injectionKey)
 	if err != nil {

--- a/test/fixtures/k8s/admissioncontrol/request/ignored-namespace.yaml
+++ b/test/fixtures/k8s/admissioncontrol/request/ignored-namespace.yaml
@@ -1,0 +1,10 @@
+---
+# this is an AdmissionRequest object
+# https://godoc.org/k8s.io/api/admission/v1beta1#AdmissionRequest
+namespace: "kube-system"
+object:
+  metadata:
+    annotations:
+      injector.unittest.com/request: "sidecar-test"
+  spec:
+    containers: []

--- a/test/fixtures/k8s/ignored-namespace-pod.yaml
+++ b/test/fixtures/k8s/ignored-namespace-pod.yaml
@@ -1,4 +1,0 @@
-name: ignored-namespace
-namespace: "ignore-me"
-annotations:
-  "injector.unittest.com/request": "volume-mounts"


### PR DESCRIPTION
# What and why?

Fixes #52.

It's possible for `metadata.namespace` and `metadata.name` to be empty in the objects passed to the webhook. This was causing the ignored namespaces check to fail for Deployment pods and the name and namespace of the pods was empty in a number of logging statements.

This PR moves the namespace check into the `mutate` function where it can access the `Namespace` field in the request object - this seems to be present for all types of request. 

It also wraps the errors returned by `getSidecarConfigurationRequested`, instead of logging them, so that the error can be logged in `mutate` along with the `Name` and `Namespace` from the request.

As mentioned in the [spec for the AdmissionRequest object](https://godoc.org/k8s.io/api/admission/v1beta1#AdmissionRequest), the name field can be omitted from the request as well, so I've replaced it with a placeholder in logging statements where it can't be taken from the request or the metadata.

# Testing Steps

Please provide adequate testing steps (including screenshots if necessary).
Include any test fixtures or sample configurations in your commit.

- [x] Added unit tests for this feature (`make test`)

# Reviewers

Required reviewers: `@byxorna`
Request reviews from other people you want to review this PR in the "Reviewers" section on the right.

> :warning: this PR must have at least 2 thumbs from the [MAINTAINERS.md](/MAINTAINERS.md) of the project before merging!
